### PR TITLE
Allow membership submissions with www in the linkedin url

### DIFF
--- a/app/models/slack_membership_submission.rb
+++ b/app/models/slack_membership_submission.rb
@@ -17,7 +17,7 @@ class SlackMembershipSubmission < ApplicationRecord
   # email is handled by Emailable concern
   validates :website_url, format: { with: %r{\Ahttps?://.*\.}, allow_blank: true }
   validates :github_url, format: { with: %r{\Ahttps?://github.com/}, allow_blank: true }
-  validates :linkedin_url, format: { with: %r{\Ahttps?://linkedin.com/in/}, allow_blank: true }
+  validates :linkedin_url, format: { with: %r{\Ahttps?://(www\.)?linkedin.com/in/}, allow_blank: true }
 
   scope :chronologically, -> { order(:created_at) }
 

--- a/spec/models/slack_membership_submission_spec.rb
+++ b/spec/models/slack_membership_submission_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe SlackMembershipSubmission, type: :model do
     it { should allow_value("").for(:linkedin_url) }
     it { should allow_value("http://linkedin.com/in/johndoe").for(:linkedin_url) }
     it { should allow_value("https://linkedin.com/in/johndoe").for(:linkedin_url) }
+    it { should allow_value("https://www.linkedin.com/in/johndoe").for(:linkedin_url) }
     it { should_not allow_value("https://notlinkedin.com/johndoe").for(:linkedin_url) }
   end
 


### PR DESCRIPTION
[My linkedin profile](https://linkedin.com/in/thomas-r-koll-78150775/) automatically redirects to the www variant of the url and because of this the submission form did complain about the url not being valid.