### PR TITLE
Upgrade nokogiri gem to fix advisory CVE-2018-8048

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'slim-rails'                                                   # slim templa
 gem "sprockets", "~> 3.7.2"                                        # sprockets is a rack-based asset packaging system that concatenates and serves javascript, scss, etc
 gem 'sucker_punch', '~> 2.0'                                       # asynchronous processing library
 gem 'uglifier', '>= 1.3.0'                                         # compressor for javascript assets
+gem 'nokogiri', '>= 1.8.3'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.7'                                      # testing framework

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -250,6 +250,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.8)
   fakeredis (~> 0.7.0)
   listen (>= 3.0.5, < 3.2)
+  nokogiri (>= 1.8.3)
   oj (~> 2.16.1)
   omniauth (= 1.8.1)
   omniauth-slack (= 2.3.0)
@@ -279,4 +280,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Vulnerability report from `bundler-audit`:

```
Name: nokogiri
Version: 1.8.2
Advisory: CVE-2018-8048
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/pull/1746
Title: Revert libxml2 behavior in Nokogiri gem that could cause XSS
Solution: upgrade to >= 1.8.3
```

This PR upgrades nokogiri gem to 1.8.4