### PR TITLE
Upgrade ffi gem to fix advisory CVE-2018-1000201

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'slim-rails'                                                   # slim templa
 gem "sprockets", "~> 3.7.2"                                        # sprockets is a rack-based asset packaging system that concatenates and serves javascript, scss, etc
 gem 'sucker_punch', '~> 2.0'                                       # asynchronous processing library
 gem 'uglifier', '>= 1.3.0'                                         # compressor for javascript assets
+gem 'ffi', '>= 1.9.24'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.7'                                      # testing framework

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     gli (2.17.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -249,6 +249,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 4.8)
   fakeredis (~> 0.7.0)
+  ffi (>= 1.9.24)
   listen (>= 3.0.5, < 3.2)
   oj (~> 2.16.1)
   omniauth (= 1.8.1)
@@ -279,4 +280,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Report from `bundler-audit`:

```
Name: ffi
Version: 1.9.23
Advisory: CVE-2018-1000201
Criticality: High
URL: https://github.com/ffi/ffi/releases/tag/1.9.24
Title: ruby-ffi DDL loading issue on Windows OS
Solution: upgrade to >= 1.9.24
```