### PR TITLE
make hamburger links railslink-red, not default blue

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,18 @@ body > nav {
       }
     }
   }
+
+  &.navbar.is-light {
+    a.navbar-burger {
+      color: #363636;
+      color: $grey-dark;
+      &:hover { color: $primary; }
+    }
+
+    a.navbar-item {
+      &:hover { color: $primary; }
+    }
+  }
 }
 
 footer {


### PR DESCRIPTION
By default the hamburger icon and links are blue. This makes them red.