### PR TITLE
Link Kate's username in the welcome message.

### DIFF
--- a/app/jobs/slack_event/team_join_job.rb
+++ b/app/jobs/slack_event/team_join_job.rb
@@ -81,6 +81,7 @@ class SlackEvent::TeamJoinJob < ApplicationJob
     )
   end
 
+  # UAS76M3HN = Kate Donaldson (kate)
   def welcome_text(user:)
     %Q(
       *Welcome to #{configatron.app_name} #{user[:real_name] || user[:name]} :wave:*
@@ -97,7 +98,7 @@ class SlackEvent::TeamJoinJob < ApplicationJob
       6. See #1.
 
       Be sure to browse all the public channels to see any topics and conversations that might be interesting to you.  We also have private channels for various interests and communities. Here's contact info if you want an invite to the following private channels:
-      - #women-in-tech: @katelovescode
+      - #women-in-tech: <@UAS76M3HN>
 
       If you're new to Ruby and/or Rails checkout <https://github.com/railslink/resources/wiki|our wiki> for resources to get started.
 


### PR DESCRIPTION
This change will linkify Kate's username in the welcome message which
will make it easier for people to ask to join #women-in-tech.

see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

![image](https://user-images.githubusercontent.com/16705/47607756-fc11fa00-d9d8-11e8-8604-3ac60968af9e.png)