### PR TITLE
welcome message upon joining #work-offers

### DIFF
--- a/app/jobs/slack_event/member_joined_channel_job.rb
+++ b/app/jobs/slack_event/member_joined_channel_job.rb
@@ -1,3 +1,21 @@
+#
+# See https://api.slack.com/events/member_joined_channel
+#
+# Example payload:
+# {"token"=>"xxxxx",
+#  "team_id"=>"T05052K3Q",
+#  "api_app_id"=>"A9MR2EQDQ",
+#  "event"=> {
+#    "type": "member_joined_channel",
+#    "user": "W06GH7XHN",
+#    "channel": "G0698JE0H",
+#    "channel_type": "C",
+#    "team": "T8MPF7EHL"},
+#  "type"=>"event_callback",
+#  "event_id"=>"EvAQE3M1PD",
+#  "event_time"=>1526446776,
+#  "authed_users"=>["U054D8V3L"]}
+#
 class SlackEvent::MemberJoinedChannelJob < ApplicationJob
 
   attr_reader :options
@@ -5,5 +23,55 @@ class SlackEvent::MemberJoinedChannelJob < ApplicationJob
 
   def perform(options = {})
     @options = options.with_indifferent_access
+    event = options[:event].with_indifferent_access
+
+    # It would be highly odd for the channel not to exist,
+    # since the only way this event is triggered is via channel-join
+    # however, the website may not yet have the channel in it's database
+    # and if it doesn't we won't be able to look it up so bail out now.
+    channel = SlackChannel.find_by(uid: event[:channel])
+    return if channel.nil?
+
+    text = text_for(channel)
+    return if text.blank?
+
+    client = Slack::Web::Client.new
+    client.chat_postEphemeral(
+      channel: event[:channel],
+      user: event[:user],
+      text: text
+    )
+
+  # This too is highly unlikely, but if the use joins and leaves quickly
+  # before this event can fire, it could happen.
+  rescue Slack::Web::Api::Errors::SlackError => e
+    raise unless %w[user_not_in_channel].include?(e.message)
   end
+
+  private
+
+  # Return the text message for the given channel. An empty response
+  # is a valid response indicating there isn't a message for that channel.
+  #
+  # The text message should not be wrapped as that will break Slack's automatic
+  # wrapping on presentation.
+  #
+  # Returns String (or nil)
+  def text_for(channel)
+    case channel.name
+    when "work-offers"
+      <<~END_OF_TEXT
+        Welcome to our job posting channel. This channel is specifically for posting job offers or job-seeking information.
+
+        For all other discussion of jobs, workplaces, career paths, etc. other than work opportunities, please use #work-career-chat.
+
+        Your job offer should include the location, remote friendliness, company name, as well as instructions on how to apply.
+
+        Be courteous and do not cross-post to other channels or post repeatedly for the same job offer. Do not pin your job post.
+
+        Please use Slack threads to followup to keep the main channel's signal to noise ratio high.
+      END_OF_TEXT
+    end
+  end
+
 end

--- a/spec/factories/slack_channel.rb
+++ b/spec/factories/slack_channel.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :slack_channel do
+    sequence(:uid) { |n| "uid#{n}" }
+    sequence(:name) { |n| "Channel #{n}" }
+  end
+end

--- a/spec/jobs/slack_event/member_joined_channel_job_spec.rb
+++ b/spec/jobs/slack_event/member_joined_channel_job_spec.rb
@@ -1,13 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe SlackEvent::MemberJoinedChannelJob, type: :job do
+  let(:channel_uid) { "channel123" }
+  let(:user_uid)    { "user13" }
+
   let(:options) {{token: "token123",
      team_id:    "team123",
      api_app_id: "appid123",
      event: {
        type:         "member_joined_channel",
-       user:         "user13",
-       channel:      "channel123",
+       user:         user_uid,
+       channel:      channel_uid,
        channel_type: "C",
        team:         "team123",
        event_ts:     "1526773280.000029"},
@@ -18,8 +21,70 @@ RSpec.describe SlackEvent::MemberJoinedChannelJob, type: :job do
   }
 
   describe "#perform" do
-    it "does nothing yet" do
-      subject.perform(options)
+    context "when SlackChannel does not exist" do
+      it "does nothing" do
+        expect(Slack::Web::Client).not_to receive(:new)
+        subject.perform(options)
+      end
+    end
+
+    context "when SlackChannel exists" do
+      let!(:channel) { create(:slack_channel, uid: channel_uid) }
+
+      context "when there is no text for channel" do
+        before do
+          channel.update!(name: "no-text-for-me")
+        end
+
+        it "does nothing" do
+          expect(subject).to receive(:text_for).and_call_original
+          expect(Slack::Web::Client).not_to receive(:new)
+          subject.perform(options)
+        end
+
+        it "squelches user_not_in_channel errors" do
+
+        end
+      end
+
+      context "when there is text for channel" do
+        before do
+          allow(subject).to receive(:text_for).and_return("string")
+        end
+
+        it "squelches user_not_in_channel errors" do
+          allow(Slack::Web::Client).to receive(:new).
+            and_raise(Slack::Web::Api::Errors::SlackError.new("user_not_in_channel"))
+
+          expect { subject.perform(options) }.not_to raise_error
+        end
+
+        it "raises other errors" do
+          allow(Slack::Web::Client).to receive(:new).
+            and_raise(Slack::Web::Api::Errors::SlackError.new("some_other_error"))
+
+          expect {
+            subject.perform(options)
+          }.to raise_error(Slack::Web::Api::Errors::SlackError)
+        end
+      end
+
+      context "when channel is #work-offers" do
+        before do
+          channel.update!(name: "work-offers")
+        end
+
+        it "posts ephmerally to user" do
+          client = double("Slack::Web::Client")
+          expect(Slack::Web::Client).to receive(:new).and_return(client)
+          expect(client).to receive(:chat_postEphemeral).with(
+            channel: channel_uid,
+            user: user_uid,
+            text: kind_of(String)
+          )
+          subject.perform(options)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
fixes #54

This PR extends the previous no-op MemberJoinedChannelJob to send an
ephemeral (user's eyes only) message upon joining #work-offers.

If you have things setup locally and integrated with either our official
slack team or the dev slack team you can trigger this manually by doing
the following (replace "phallstrom" with your username)

```
user = SlackUser.find_by_username("phallstrom")
channel = SlackChannel.find_by_name("work-offers")
SlackEvent::MemberJoinedChannelJob.new.perform({event: {channel: channel.uid, user: user.uid}})
```

Unfortunately there's no good way to test this without deploying as it
requires Slack's web event hooks to trigger it.  So there's a slight
chance it won't work, but it also won't break anything.