### PR TITLE
Adds User show page

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,4 +2,7 @@ class Admin::UsersController < ApplicationController
   def index
     @users = SlackUser.order(:is_deleted).order(is_admin: :desc).order(:last_name, :email)
   end
+  def show
+    @user = SlackUser.find(params[:id])
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < AdminController
   def index
     @users = SlackUser.order(:is_deleted).order(is_admin: :desc).order(:last_name, :email)
   end

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -12,6 +12,7 @@ section.section
             th Created At
             th Email
             th Timezone
+            th
         tbody
           - @users.each do |user|
             tr[class = (user.is_deleted? ? "has-text-grey-light" : "")]
@@ -21,3 +22,4 @@ section.section
               td= user.created_at.to_date.to_s(:db)
               td= user.email
               td= user.tz
+              td= link_to "View", admin_user_path(user.id), class: "button"

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,41 @@
+section.section
+  .columns
+    .column
+      h1.title #{@user.first_name || @user.last_name ? @user.name + " - " : ""} #{@user.email}
+
+  .columns
+    .column
+      .field
+        label.label Name
+        .control
+          input.input[type="text" disabled value=@user.name]
+
+      .field
+        label.label Email
+        .control
+          input.input[type="email" disabled value=@user.email]
+
+      .field
+        label.label Locale
+        .control
+          input.input[type="text" disabled value=@user.locale]
+
+      .field
+        label.label Timezone
+        .control
+          input.input[type="text" disabled value=@user.tz]
+    
+    .column
+      .field
+        label.label Deleted #{@user.is_deleted ? "✓" : ""}
+
+      .field
+        label.label Admin #{@user.is_admin ? "✓" : ""}
+
+      .field
+        label.label Bot #{@user.is_bot ? "✓" : ""}
+
+      .field
+        label.label Last Message At
+        .control
+          input.input[type="text" disabled value=@user.last_message_at]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get "/admin", to: "admin/dashboard#index", as: :admin
 
   namespace :admin do
-    resources "users", only: [:index]
+    resources "users", only: [:index, :show]
     resources "channels", only: [:index]
 
     resources "membership_submissions" do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -4,7 +4,19 @@ RSpec.describe Admin::UsersController, type: :controller do
 
   describe "GET #index" do
     it "returns http success" do
+      authorize_admin!
       get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #show" do
+    before do
+      create(:slack_user)
+    end
+    it "returns http success" do
+      authorize_admin!
+      get :show, { params: {id: SlackUser.first.id } }
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
## 📋 Summary
Adds a User show page and a view button to the users index page so you can access it.  Also changes the users controller to inherit from the admin controller so it requires an admin to access it.

## ✅ Steps to set up locally
* Restart the server

## 📐 Steps to test
* Visit `localhost:3000/admin`
* Click on "Users" in the nav bar
* Click "View" next to a User
* See their non-editable show page
* RSpec should pass with the new controller test example

## ⁉ Caveats, concerns
Okay for real this is UGLY.  I am not a front-end designer and I just kind of hacked this out, but it looks like this:

![screen shot 2018-10-31 at 1 14 53 pm](https://user-images.githubusercontent.com/8364647/47809671-757a5700-dd0f-11e8-9b5e-1452615d4afa.png)

Please somebody give me some guidance on how the heck this should look and I'll make it happen.  I made the booleans a label w/ a check if it's true, but that looks horrible.