### PR TITLE
Use "rails" instead of "rake" to run migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-release: rake db:migrate
+release: bundle exec rails db:migrate


### PR DESCRIPTION
This is the new format and I believe `rake` tasks could be removed in the future.