### PR TITLE
[WIP] Sets up the Slack command method to build slash commands

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   namespace :slack do
     post "event"
   end
+  
+  post "/slack/:command", to: "slack#command"
 
   get "/login"                   , to: "sessions#new"     , as: :login
   get "/logout"                  , to: "sessions#destroy" , as: :logout


### PR DESCRIPTION
Fixes #81 

Adds a route for slack commands, and a `command` method in the Slack controller that currently calls the `list_admins` method when a call is made to `/slack/admins`.

**Things to note:**

- I believe the `publish_event` and `verify_token!` methods are only needed for web events, so I set them to only fire on the existing `event` method.  I'm unsure where the strong params (`slack_params`) called in those methods are being built; it might be because I'm not very clear on front-end stuff, but I'm not sure how the params from Slack are encased in the parent slack object that the strong params are expecting, e.g. `{ slack: { type: "", etc. } }` - I'd prefer to format the params from the slash command the same way but might need help.  Right now the params that get passed from the slack command are as follows:
```
{
  "token"=>"[token]",
  "team_id"=>"[team_id]",
  "team_domain"=>"[team_domain]",
  "channel_id"=>"[channel_id]",
  "channel_name"=>"[channel_name]",
  "user_id"=>"[user_id]",
  "user_name"=>"[username]",
  "command"=>"admins",
  "text"=>"",
 "response_url"=>"https://hooks.slack.com/commands/[hash]/[hash]/[hash]",
  "trigger_id"=>"[id]"
}
```

**TODO**

- randomize the order
- output the names as hyperlinks to usernames instead of an array of usernames
- write tests