### PR TITLE
Add Contact Page for Administrators

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,11 @@ body > nav {
     margin: 1rem 0;
   }
 
+  img {
+    filter: grayscale(1);
+    transition-duration: 0.4s;
+  }
+
   .card:hover img {
     filter: none;
     transform: scale(1.02);
@@ -61,11 +66,6 @@ body > nav {
 
   .card-image {
     padding: 1rem 0;
-  }
-
-  img {
-    filter: grayscale(1);
-    transition-duration: 0.4s;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -67,6 +67,10 @@ body > nav {
   .card-image {
     padding: 1rem 0;
   }
+
+  .title {
+    margin: 0;
+  }
 }
 
 footer {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,6 +49,26 @@ body > nav {
   }
 }
 
+.site-admins {
+  header {
+    margin: 1rem 0;
+  }
+
+  .card:hover img {
+    filter: none;
+    transform: scale(1.02);
+  }
+
+  .card-image {
+    padding: 1rem 0;
+  }
+
+  img {
+    filter: grayscale(1);
+    transition-duration: 0.4s;
+  }
+}
+
 footer {
   border-top: 1px solid $grey-lighter;
   margin-top: 1rem;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,6 +59,16 @@ body > nav {
     transition-duration: 0.4s;
   }
 
+  .is-equal-height {
+    @media screen and (min-width: 769px) {
+      display: flex;
+
+      .card {
+        width: 100%;
+      }
+    }
+  }
+
   .card:hover img {
     filter: none;
     transform: scale(1.02);

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def admin
+    @admin_members = SlackUser.admins
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
   def admin
-    @admin_members = SlackUser.admins
+    @admin_members = SlackUser.admins.active.sort_by_recent_activity
   end
 end

--- a/app/models/slack_user.rb
+++ b/app/models/slack_user.rb
@@ -14,6 +14,8 @@ class SlackUser < ApplicationRecord
   scope :bots, -> { where(is_bot: true) }
   scope :human, -> { where(is_bot: false) }
   scope :available, -> { extant.human }
+  scope :active, -> { available.where.not(last_message_at: nil) }
+  scope :sort_by_recent_activity, -> { order(last_message_at: :desc) }
 
   def self.find_or_create_from_auth_hash(auth_hash)
     user = find_or_create_from_api_response(auth_hash.extra.user_info.user)

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -4,19 +4,21 @@ footer.container
 
       - unless in_admin_space?
         p
-          | Have a question? Read our 
-          = link_to 'Resources Wiki', 'https://github.com/railslink/resources/wiki', target: 'new'
-          | , or ask us on 
-          = link_to 'Twitter', 'https://twitter.com/railslink', target: 'new'
+          | Have a question? Read our
+          = link_to ' Resources Wiki', 'https://github.com/railslink/resources/wiki', target: 'new'
+          | , Contact the
+          = link_to ' Admins', admin_members_path
+          | , or ask us on
+          = link_to ' Twitter', 'https://twitter.com/railslink', target: 'new'
           | .
         .links
           a href="https://twitter.com/railslink" target="_new"
             span.icon.is-large: i class="fab fa-twitter fa-2x"
-          a href="https://www.facebook.com/groups/railslink/" target="_new" 
+          a href="https://www.facebook.com/groups/railslink/" target="_new"
             span.icon.is-large: i class="fab fa-facebook fa-2x"
-          a href="https://github.com/railslink/railslink" target="_new" 
+          a href="https://github.com/railslink/railslink" target="_new"
             span.icon.is-large: i class="fab fa-github fa-2x"
-          a href="https://www.producthunt.com/tech/rubyonrails-link" target="_new" 
+          a href="https://www.producthunt.com/tech/rubyonrails-link" target="_new"
             span.icon.is-large: i class="fab fa-product-hunt fa-2x"
 
       .copyright ©#{Time.zone.now.year} #{configatron.app_name}

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -6,7 +6,7 @@ footer.container
         p
           | Have a question? Read our
           = link_to ' Resources Wiki', 'https://github.com/railslink/resources/wiki', target: 'new'
-          | , Contact the
+          | , contact the
           = link_to ' Admins', admin_members_path
           | , or ask us on
           = link_to ' Twitter', 'https://twitter.com/railslink', target: 'new'

--- a/app/views/pages/admin.html.slim
+++ b/app/views/pages/admin.html.slim
@@ -1,0 +1,22 @@
+main.site-admins
+  section.section
+    header.has-text-centered
+      h1.is-size-1 Admin Members
+      p You can contact any of the following administrators
+
+    main.container
+      .columns.is-multiline
+        - @admin_members.each do |member|
+          .column.is-12-mobile.is-6-tablet.is-4-desktop
+            .card.has-text-centered
+              .card-image = image_tag member.data["profile"]["image_192"]
+
+              .card-content
+                h3.title
+                  = member.data["profile"]["real_name"]
+
+              .card-footer
+                .card-footer-item
+                  = link_to "mailto:#{member.data['profile']['email']}", class: "button is-fullwidth is-medium" do
+                    | Contact &nbsp;
+                    i.fas.fa-envelope

--- a/app/views/pages/admin.html.slim
+++ b/app/views/pages/admin.html.slim
@@ -7,7 +7,7 @@ main.site-admins
     main.container
       .columns.is-multiline
         - @admin_members.each do |member|
-          .column.is-12-mobile.is-6-tablet.is-4-desktop
+          .column.is-12-mobile.is-6-tablet.is-4-desktop.is-equal-height
             .card.has-text-centered
               .card-image = image_tag member.data["profile"]["image_192"]
 

--- a/app/views/pages/admin.html.slim
+++ b/app/views/pages/admin.html.slim
@@ -2,7 +2,7 @@ main.site-admins
   section.section
     header.has-text-centered
       h1.is-size-1 Admin Members
-      p You can contact any of the following administrators
+      p You can contact any of the following administrators on slack
 
     main.container
       .columns.is-multiline
@@ -14,9 +14,7 @@ main.site-admins
               .card-content
                 h3.title
                   = member.data["profile"]["real_name"]
-
-              .card-footer
-                .card-footer-item
-                  = link_to "mailto:#{member.data['profile']['email']}", class: "button is-fullwidth is-medium" do
-                    | Contact &nbsp;
-                    i.fas.fa-envelope
+                - if member.data["profile"]["display_name"].present?
+                  span
+                    | @
+                    = member.data["profile"]["display_name"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,6 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  get "/admin_members", to: "pages#admin"
 end


### PR DESCRIPTION
Fixes #85 

There is a need to display the administrators of the platform so that users can easily contact them with any queries that they might have.

This PR addresses the need by:

* Adding an admin_members route to the list of routes
* Adding a controller and the necessary view to display the current list of administrators on the platform
* Adding a link from the homepage to the new admin_members contact page

<img width="1280" alt="screen shot 2019-02-09 at 3 11 49 pm" src="https://user-images.githubusercontent.com/7131935/52521806-22546080-2c7d-11e9-9e23-1262746f8c3f.png">
<img width="318" alt="screen shot 2019-02-09 at 3 12 08 pm" src="https://user-images.githubusercontent.com/7131935/52521807-22546080-2c7d-11e9-82fb-6653c646fe5b.png">
