### PR TITLE
add exception handling to ip_info

### DIFF
--- a/app/models/ip_info.rb
+++ b/app/models/ip_info.rb
@@ -4,7 +4,11 @@
 class IpInfo
   def initialize(ip_address)
     @ip_address = ip_address
-    @info = JSON.parse(Net::HTTP.get("ip-api.com", "/json/#{@ip_address}"))
+    Timeout::timeout(3) do
+      @info = JSON.parse(Net::HTTP.get("ip-api.com", "/json/#{@ip_address}"))
+    end
+  rescue Net::OpenTimeout, JSON::ParserError, Timeout::Error
+    @info = {}
   end
 
   def successful?

--- a/spec/models/ip_info_spec.rb
+++ b/spec/models/ip_info_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe IpInfo, type: :model do
+  context "exceptions" do
+    let(:subject) { described_class.new("73.11.237.17") }
+
+    it "is unsuccessful when the network times out" do
+      allow(Net::HTTP).to receive(:get).and_raise(Net::OpenTimeout)
+      expect(subject.successful?).to eq false
+    end
+
+    it "is unsuccessful when the json is invalid" do
+      allow(Net::HTTP).to receive(:get).and_return("") # invalid JSON
+      expect(subject.successful?).to eq false
+    end
+
+    it "is unsuccessful when the timeout is reached" do
+      allow(Net::HTTP).to receive(:get).and_raise(Timeout::Error)
+      expect(subject.successful?).to eq false
+    end
+  end
+
   context "invalid ip addresses" do
     let(:subject) { described_class.new("invalid") }
 


### PR DESCRIPTION
This adds exception handling for when ip info look ups fail for whatever
reason. See:

https://rollbar.com/railslink/railslink/items/25/
https://rollbar.com/railslink/railslink/items/26/