### PR TITLE
tweak /admins output to link usernames and only show active admins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.4.4-alpine
 
 RUN apk add --update --no-cache \
   build-base \
+  less \
   libxml2-dev \
   libxslt-dev \
   nodejs \

--- a/app/jobs/slack_event/admins_job.rb
+++ b/app/jobs/slack_event/admins_job.rb
@@ -52,7 +52,9 @@ class SlackEvent::AdminsJob < ApplicationJob
   <<~END_OF_TEXT
     *#{configatron.app_name} Admin Members*
     You can contact any of the following administrators on Slack or via email.
+
     #{admin_string}
+
     This information is also available at https://www.rubyonrails.link/admin_members
     END_OF_TEXT
   end
@@ -61,7 +63,7 @@ class SlackEvent::AdminsJob < ApplicationJob
     admins = SlackUser.admins.active.shuffle
     admins.map! do |admin|
       activity = "last active #{ApplicationController.helpers.time_ago_in_words(admin.last_message_at)} ago"
-      " - <@#{admin.uid}>, #{admin.email} _(#{activity})_"
+      " - <@#{admin.uid}> | #{admin.email} _(#{activity})_"
     end
     admins.join("\n")
   end

--- a/app/jobs/slack_event/admins_job.rb
+++ b/app/jobs/slack_event/admins_job.rb
@@ -50,21 +50,20 @@ class SlackEvent::AdminsJob < ApplicationJob
   # Returns String (or nil)
   def admin_text
   <<~END_OF_TEXT
-    Admins and their contact information:
+    *#{configatron.app_name} Admin Members*
+    You can contact any of the following administrators on Slack or via email.
     #{admin_string}
+    This information is also available at https://www.rubyonrails.link/admin_members
     END_OF_TEXT
   end
 
   def admin_string
-    admins_string = ""
-    SlackUser.admins.shuffle.each do |admin|
-      name = admin.name
-      email = admin.try(:email) ? "email: #{admin.email}" : nil
-      tz = admin.try(:tz) ? "timezone: #{admin.tz}" : nil
-      activity = admin.try(:last_message_at) ? "last activity: #{admin.last_message_at}" : nil
-      admins_string << "#{ [name, email, tz, activity].compact.join(" | ") }\n"
+    admins = SlackUser.admins.active.shuffle
+    admins.map! do |admin|
+      activity = "last active #{ApplicationController.helpers.time_ago_in_words(admin.last_message_at)} ago"
+      " - <@#{admin.uid}>, #{admin.email} _(#{activity})_"
     end
-    admins_string
+    admins.join("\n")
   end
 
 end


### PR DESCRIPTION
This patch does a few things, mostly around formatting the output from
`/admins`.

- It adds `less` to the Dockerfile so that pagination in pry (ie. rails
console) inside Docker works.  Alpine's default less doesn't support
`-R`.

- It adjusts the admins selected to only those that have chatted at
least once. This mostly has the effect of excluding the
slack@rubyonrails.link "owner".  It also only selects humans should we
have a future admin that is a bot (not even sure that's possible
though).

- It formats the output to link their username so admins are easily
DMable. Doing this also alleviates the need ot show their name as that
is done automatically by Slack.

- It removes timezone and formats the last activity from a timestamp to
relative time as that's easier to grok.

- It adds some intro text and postscript about where this info is available on the web.

test plan:
  - you could try it out on the dev channel or trust the screenshot I've
    attached.

<img width="640" alt="Screen Shot 2019-05-30 at 10 18 33 PM" src="https://user-images.githubusercontent.com/16705/58683552-a3695d80-8329-11e9-9fa3-030458e75e47.png">