### PR TITLE
Removes the CVE that's breaking from the audit check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           command: gem install bundler-audit
       - run:
           name: Run bundle-audit
-          command: bundle audit check --update --ignore CVE-2015-9284
+          command: bundle audit check --update --ignore CVE-2015-9284 # this cve deals with a vulnerability for multiple auth providersw, which we do not have
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,6 @@ jobs:
                             --format progress \
                             $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
-
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
@@ -110,7 +109,7 @@ jobs:
           command: gem install bundler-audit
       - run:
           name: Run bundle-audit
-          command: bundle audit check --update
+          command: bundle audit check --update --ignore CVE-2015-9284
 
 workflows:
   version: 2
@@ -127,4 +126,3 @@ workflows:
             branches:
               only:
                 - master
-        

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           command: gem install bundler-audit
       - run:
           name: Run bundle-audit
-          command: bundle audit check --update --ignore CVE-2015-9284 # this cve deals with a vulnerability for multiple auth providersw, which we do not have
+          command: bundle audit check --update --ignore CVE-2015-9284 # this cve deals with a vulnerability for multiple auth providers, which we do not have
 
 workflows:
   version: 2

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -6,4 +6,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     team: ENV["SLACK_TEAM"],
     scope: "channels:read, users:read",
     setup: true
+  # if we ever add additional providers, we'll have to look out for csrf vulnerability in CVE-2015-9284
+  # https://github.com/rubysec/ruby-advisory-db/pull/390#issuecomment-509105361
 end


### PR DESCRIPTION
We can ignore this CVE for now until a solution is merged into omniauth; the problem is still present in 1.9.0 so I don't see a need to upgrade it right now.  Meanwhile, because we're only using one login provider, this _shouldn't_ affect us.  We should keep an eye out on patches for OmniAuth in the future, and we could feasibly change all our `get` auth requests to `post` requests, which would also probably help, but it might be overkill.