### PR TITLE
Ensure Restart with Existing PID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ EXPOSE 3000
 
 ENTRYPOINT ["/usr/src/app/bin/docker-entrypoint.sh"]
 
-CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0", "-p", "3000"]
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0", "-p", "3000", "-P", "/tmp/rails_server.pid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.5.7-alpine
 
+ENV APP_DIR /usr/src/app
+
 RUN apk add --update --no-cache \
   build-base \
   less \
@@ -11,7 +13,7 @@ RUN apk add --update --no-cache \
   tini \
   tzdata
 
-WORKDIR /usr/src/app
+WORKDIR $APP_DIR
 
 COPY . ./
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-# remove the server.pid
-if [ -f $APP_DIR/tmp/pids/server.pid ]; then
-  echo "---- REMOVING pid from $APP_DIR ----"
-  rm $APP_DIR/tmp/pids/server.pid
-fi
-
 bundle check || bundle install
 
 exec /sbin/tini -- "$@"

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # remove the server.pid
-#
+rm /usr/src/app/tmp/pids/server.pid
 
 bundle check || bundle install
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# remove the server.pid
+#
+
 bundle check || bundle install
 
 exec /sbin/tini -- "$@"

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 # remove the server.pid
-rm /usr/src/app/tmp/pids/server.pid
+if [ -f $APP_DIR/tmp/pids/server.pid ]; then
+  echo "---- REMOVING pid from $APP_DIR ----"
+  rm $APP_DIR/tmp/pids/server.pid
+fi
 
 bundle check || bundle install
 


### PR DESCRIPTION
Sometimes, developers — like me — could get impatient and not stop the server properly. In this case, when the container is brought back up, the server cannot be started because there is a zombie process holding on to the port.

```
web_1    | A server is already running. Check /usr/src/app/tmp/pids/server.pid.
web_1    | => Booting Puma
web_1    | => Rails 5.1.6.2 application starting in development
web_1    | => Run `rails server -h` for more startup options
```

This change ensures we remove the `server.pid` file on startup