### PR TITLE
DM user's who use /invite_people to use web form

### DIFF
--- a/app/jobs/slack_event/message_job.rb
+++ b/app/jobs/slack_event/message_job.rb
@@ -1,23 +1,6 @@
 #
 # See https://api.slack.com/events-api#receiving_events
 #
-# Example payload:
-#   {"token"=>"xxxxx",
-#   "team_id"=>"T05052K3Q",
-#   "api_app_id"=>"A9MR2EQDQ",
-#   "event"=>{
-#     "type"=>"message",
-#     "user"=>"U6D5W3NCC",
-#     "text"=>"something",
-#     "ts"=>"1526446776.000167",
-#     "channel"=>"C05052K88",
-#     "event_ts"=>"1526446776.000167",
-#     "channel_type"=>"channel"},
-#   "type"=>"event_callback",
-#   "event_id"=>"EvAQE3M1PD",
-#   "event_time"=>1526446776,
-#   "authed_users"=>["U054D8V3L"]}
-#
 class SlackEvent::MessageJob < ApplicationJob
 
   attr_reader :options
@@ -25,13 +8,101 @@ class SlackEvent::MessageJob < ApplicationJob
 
   def perform(options = {})
     @options = options.with_indifferent_access
+
+    %i[
+    request_to_invite
     update_last_message_at
+    ].each do |method|
+      return if send(method)
+    end
   end
 
   private
 
+  # Example payload:
+  # {"token"=>"1mgp0bBfXC5V7XaGnV7e0RIY",
+  #  "team_id"=>"TCF0ZD3LL",
+  #  "api_app_id"=>"ACELG3B4H",
+  #  "event"=>
+  #   {"bot_id"=>"B01",
+  #    "type"=>"message",
+  #    "text"=>"<@UQ5TPSAKG> requested to invite one person to this workspace.",
+  #    "user"=>"USLACKBOT",
+  #    "ts"=>"1572807140.000900",
+  #    "team"=>"TCF0ZD3LL",
+  #    "attachments"=>
+  #     [{"text"=> "*Name*: Philip Two\n*Email*: <mailto:philip+2@pjkh.com|philip+2@pjkh.com>", "id"=>1},
+  #      {"text"=>"*Channel:* <#CPQSZEM34|admin-invitations>", "id"=>2},
+  #      {"text"=>"*Reason for Request*:\nthe reason i'm inviting", "id"=>3},
+  #      {"callback_id"=>"inviterequests_TCF0ZD3LL",
+  #       "fallback"=>"Approve/Deny the invite request on team site",
+  #       "id"=>4,
+  #       "actions"=>
+  #        [{"id"=>"1", "name"=>"approve", "text"=>"Send Invitation", "type"=>"button", "value"=>"819741771957", "style"=>"primary"},
+  #         {"id"=>"2", "name"=>"deny", "text"=>"Deny", "type"=>"button", "value"=>"819741771957", "style"=>"danger"}]}],
+  #    "channel"=>"CPQSZEM34",
+  #    "event_ts"=>"1572807140.000900",
+  #    "channel_type"=>"channel"},
+  #  "type"=>"event_callback",
+  #  "event_id"=>"EvQ5HCAE6T",
+  #  "event_time"=>1572807140,
+  #  "authed_users"=>["UCFC0B6E9"]}
+  def request_to_invite
+    return false unless options.dig(:event, :text).to_s.match?(/ requested to invite .* to this workspace./)
+    return false unless options.dig(:event, :attachments).any? { |e| e[:fallback] =~ /invite request on team site/ }
+
+    user_id = options.dig(:event, :text).match(/^<@(.*?)>/).captures.first
+
+    message = %Q(
+      Hi - You recently invited someone to join this Slack team via the slash
+      command `/invite_people`. To help reduce the number of bots and spam
+      accounts we ask that everyone join by filling out the form below:
+
+      https://www.rubyonrails.link/join-now
+
+      Will you ask your friend to fill out that form? Once done our goal is to
+      review and approve it in 24 hours.
+
+      Thanks!
+
+      _– RBot and the Admins_
+    )
+
+    client = Slack::Web::Client.new
+    dm_channel = client.im_open(user: user_id).channel.id
+    client.chat_postMessage(
+      as_user: true,
+      channel: dm_channel,
+      text: message,
+      mrkdwn: true,
+      unfurl_links: false,
+      unfurl_media: false
+    )
+
+    true
+  end
+
+  # Example payload:
+  #   {"token"=>"xxxxx",
+  #   "team_id"=>"T05052K3Q",
+  #   "api_app_id"=>"A9MR2EQDQ",
+  #   "event"=>{
+  #     "type"=>"message",
+  #     "user"=>"U6D5W3NCC",
+  #     "text"=>"something",
+  #     "ts"=>"1526446776.000167",
+  #     "channel"=>"C05052K88",
+  #     "event_ts"=>"1526446776.000167",
+  #     "channel_type"=>"channel"},
+  #   "type"=>"event_callback",
+  #   "event_id"=>"EvAQE3M1PD",
+  #   "event_time"=>1526446776,
+  #   "authed_users"=>["U054D8V3L"]}
+  #
   def update_last_message_at
     SlackUser.where(uid: options[:event][:user]).
       update_all(last_message_at: Time.at(options[:event][:event_ts].to_i))
+
+    true
   end
 end

--- a/app/jobs/slack_event/message_job.rb
+++ b/app/jobs/slack_event/message_job.rb
@@ -66,7 +66,7 @@ class SlackEvent::MessageJob < ApplicationJob
       Thanks!
 
       _– RBot and the Admins_
-    )
+    ).strip.gsub(/^ +/, '')
 
     client = Slack::Web::Client.new
     dm_channel = client.im_open(user: user_id).channel.id

--- a/spec/jobs/slack_event/message_job_spec.rb
+++ b/spec/jobs/slack_event/message_job_spec.rb
@@ -1,12 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe SlackEvent::MessageJob, type: :job do
+  describe "#request_to_invite" do
+    context "when not an invitation request" do
+      it "won't invoke when message text is wrong" do
+        expect(subject).to receive(:request_to_invite).and_return(false)
+        payload = { event: { text: "not an invitation request" } }
+        subject.perform(payload)
+      end
+
+      it "won't invoke when fallback text is wrong" do
+        expect(subject).to receive(:request_to_invite).and_return(false)
+        payload = { event: {
+          text: "<@UQ5TPSAKG> requested to invite one person to this workspace.",
+          attachments: [{fallback: "not an approve or deny fallback"}]
+        } }
+        subject.perform(payload)
+      end
+    end
+
+    context "when an invitation request" do
+      let(:user_id) { "UQ5TPSAKG" }
+      let(:payload) {{
+        event: {
+          text: "<@#{user_id}> requested to invite one person to this workspace.",
+          attachments: [{fallback: "Approve/Deny the invite request on team site"}]
+        }
+      }}
+
+      it "sends a dm to the user" do
+        client = double(Slack::Web::Client)
+        im = double(channel: double(id: 123))
+        expect(Slack::Web::Client).to receive(:new).and_return(client)
+        expect(client).to receive(:im_open).with(user: user_id).and_return(im)
+        expect(client).to receive(:chat_postMessage).with(hash_including(
+          channel: 123,
+          text: kind_of(String)
+        ))
+        subject.perform(payload)
+      end
+    end
+  end
+
   describe "#update_last_message_at" do
     it "updates the user's last_message_at attribute" do
       user = create(:slack_user)
       event_ts = Time.current
       subject.perform( event: { user: user.uid, event_ts: event_ts.to_f.to_s })
       expect(user.reload.last_message_at.to_i).to eq event_ts.to_i
+    end
+
+    it "won't invoke if a previous handler processes the message" do
+      allow(subject).to receive(:request_to_invite).and_return(true)
+      subject.perform({})
+      expect(subject).not_to receive(:update_last_message_at)
     end
   end
 end


### PR DESCRIPTION
Awhile ago Slack made a change so that anyone can use /invite_people to
invite anyone to the Slack team. We prefer that people use the signup
form so we can review them before approval.

We've configured the Slack instance to send these messages to
`#admin-invitations`, but we still have to then DM the requestor and ask
them to point their invitee to the signup form.

This patch extends the MessageJob slack event job to watch for these
messages in `#admin-invitations`, and DM the requestor on our behalf.

Testing this is a little complicated as it requires you be a NON-ADMIN member of the railslink-dev site as admins bypass the approval process. But you can invite a version of yourself and use that account to invite someone else.  I have deployed this branch to railslink-dev site so you can test if it you'd like.

Or.. trust me. I created a non-admin user and as that user invited another person. Below is the message I get DMd within a few seconds of sending the invitation.
<img width="535" alt="Screen Shot 2019-11-03 at 11 47 13 AM" src="https://user-images.githubusercontent.com/16705/68091048-f773f300-fe2f-11e9-8aef-ea03b1e38bd0.png">
