### PR TITLE
remove is_heroku_dev_app check

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,4 @@ class ApplicationController < ActionController::Base
 
   include CurrentUser
   include Pagy::Backend
-
-  # Can't use Rails.env here as both the dev and prod sites run as production.
-  def is_railslink_dev_heroku?
-    request.host == "railslink-dev.herokuapp.com"
-  end
 end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -11,8 +11,6 @@ class SlackController < ApplicationController
       return
     end
 
-    SlackEvent::UnhandledJob.perform_later(slack_params.to_hash) if is_railslink_dev_heroku?
-
     case slack_params.fetch(:event, {})[:type]
     when "admins"
       SlackEvent::AdminsJob.perform_later(slack_params.to_hash)

--- a/spec/requests/slack_post_event_spec.rb
+++ b/spec/requests/slack_post_event_spec.rb
@@ -114,39 +114,5 @@ RSpec.describe "Slack post event", type: :request do
         post "/slack/event", params: { slack: slack_params }
       end
     end
-
-    context "host is not railslink-dev.herokuapp.com" do
-      it "does not enqueue SlackEvent::UnhandledJob in addition to the normal job" do
-        slack_params = {
-          token: token,
-          event: {
-            type: "message",
-            user: "u123"
-          }
-        }.with_indifferent_access
-        expect(SlackEvent::UnhandledJob).not_to receive(:perform_later)
-        expect(SlackEvent::MessageJob).to receive(:perform_later).with(slack_params)
-        post "/slack/event",
-          params: { slack: slack_params },
-          headers: { "Host" => "not-railslink-dev.herokuapp.com" }
-      end
-    end
-
-    context "host is railslink-dev.herokuapp.com" do
-      it "enqueues SlackEvent::UnhandledJob in addition to the normal job" do
-        slack_params = {
-          token: token,
-          event: {
-            type: "message",
-            user: "u123"
-          }
-        }.with_indifferent_access
-        expect(SlackEvent::UnhandledJob).to receive(:perform_later).with(slack_params)
-        expect(SlackEvent::MessageJob).to receive(:perform_later).with(slack_params)
-        post "/slack/event",
-          params: { slack: slack_params },
-          headers: { "Host" => "railslink-dev.herokuapp.com" }
-      end
-    end
   end
 end


### PR DESCRIPTION
It turns out we don't need this because we already do redis publishing
of all events and I just need to subscribe to it to see it. I even wrote
that code, but forgot about it.

So this just removes something that I never should have added in the
first place.