### PR TITLE
Gem upgrades for security audit failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           command: gem install bundler-audit
       - run:
           name: Run bundle-audit
-          command: bundle audit check --update --ignore CVE-2015-9284 CVE-2020-5267 
+          command: bundle audit check --update --ignore CVE-2015-9284 CVE-2020-5267 CVE-2020-8166
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'marginalia', '~> 1.6.0'                                       # attach comm
 gem 'oj', '~> 3.9.2'                                               # fast json parser and object serializer
 gem 'pg', '>= 0.18', '< 2.0'                                       # use postgresql as the database
 gem 'pagy', '~> 0.21.0'                                            # pagination ruby gem
-gem 'puma', '~> 3.12'                                              # use puma as the app server
+gem 'puma', '~> 3.12.6'                                            # use puma as the app server
 gem 'rack-attack', '~> 5.2.0'                                      # rack middleware for blocking & throttling abusive requests
 gem 'rails-assets-bulma', source: 'https://rails-assets.org'       # modern css framework based on flexbox
 gem 'rails-assets-chartjs', source: 'https://rails-assets.org'     # html5 charts using the canvas element

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,8 +138,8 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
-    puma (3.12.4)
-    rack (2.0.8)
+    puma (3.12.6)
+    rack (2.2.2)
     rack-attack (5.2.0)
       rack
     rack-test (1.1.0)
@@ -293,7 +293,7 @@ DEPENDENCIES
   pagy (~> 0.21.0)
   pg (>= 0.18, < 2.0)
   pry-rails
-  puma (~> 3.12)
+  puma (~> 3.12.6)
   rack-attack (~> 5.2.0)
   rails (~> 5.1.6.2)
   rails-assets-bulma!


### PR DESCRIPTION
- update puma and rack due to CVE-2020-11076, CVE-2020-11077, CVE-2020-8161
- ignore CVE-2020-8166