### PR TITLE
Fix Heroku Puma config to not specify pidfile

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,7 +16,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together


### PR DESCRIPTION
Heroku docs
https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#config
don't mention the need to specify this in the puma config.