### PR TITLE
Remove CVE ignores from CI security checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
           command: gem install bundler-audit
       - run:
           name: Run bundle-audit
-          command: bundle audit check --update --ignore CVE-2015-9284 CVE-2020-5267 CVE-2020-8164 CVE-2020-8165 CVE-2020-8167 CVE-2020-8166 
+          command: bundle audit check --update --ignore CVE-2015-9284
 
 workflows:
   version: 2


### PR DESCRIPTION
With the upgrading of the application to Rails 5.2.4.4 there is no
longer a need to ignore some CVE issues that affected earlier versions
of Rails.