### PR TITLE
Add a space to homepage to correct typo

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -19,8 +19,8 @@ section.section.has-text-centered
       h2.subtitle.is-3 Who We Are
       p
         | We are #{number_with_delimiter @team_members_count} Ruby on Rails developers from all over the world, 
-        | including avid OSS contributors, full-stack engineers, startup founders, 
-        | backend engineers, and people just learning Ruby on Rails.
+          including avid OSS contributors, full-stack engineers, startup founders,
+          backend engineers, and people just learning Ruby on Rails.
 
 hr
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -19,7 +19,7 @@ section.section.has-text-centered
       h2.subtitle.is-3 Who We Are
       p
         | We are #{number_with_delimiter @team_members_count} Ruby on Rails developers from all over the world, 
-        | including avid OSS contributors, full-stack engineers, startup founders,
+        | including avid OSS contributors, full-stack engineers, startup founders, 
         | backend engineers, and people just learning Ruby on Rails.
 
 hr


### PR DESCRIPTION
Changes "founders,backend" to "founders, backend" on the main landing page
![ksnip_20210914-230626](https://user-images.githubusercontent.com/24377351/133340461-1e2884ac-27ea-4c2e-a65a-83d8b2704060.png)

