### PR TITLE
Nokogiri update throws error when running the server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV APP_DIR /usr/src/app
 RUN apk add --update --no-cache \
   bash \
   build-base \
+  gcompat \
   less \
   libxml2-dev \
   libxslt-dev \


### PR DESCRIPTION
https://nokogiri.org/tutorials/installing_nokogiri.html\#linux-musl-error-loading-shared-library - this has the fix; I updated the dockerfile to install this library at runtime.  Might not be an issue on the deployed environment but is for local dev.