### PR TITLE
Fix: format Slack channel purpose to show readable channel names

### DIFF
--- a/app/presenters/slack_channel_presenter.rb
+++ b/app/presenters/slack_channel_presenter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SlackChannelPresenter < BasePresenter
+  def cleaned_purpose
+    return "" if purpose.blank?
+
+    purpose.gsub(/<#(C\w+)\|([^>]+)>/, '#\2')
+  end
+end

--- a/app/views/admin/channels/index.html.slim
+++ b/app/views/admin/channels/index.html.slim
@@ -16,4 +16,4 @@ section.section
               td= channel.name_with_hash
               td.has-text-right= number_with_delimiter channel.members_count
               td.has-text-right= channel.created_at.to_date.to_s(:db)
-              td= channel.purpose
+              td= SlackChannelPresenter.new(channel).cleaned_purpose

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -35,7 +35,7 @@ section.section.has-text-centered
           .column.is-4.has-text-left
             .has-text-grey.is-size-4= channel.name_with_hash
             p 
-              = channel.purpose
+              = SlackChannelPresenter.new(channel).cleaned_purpose
               br
               span.has-text-primary #{number_with_delimiter channel.members_count}
               span.has-text-grey-light< members

--- a/spec/presenters/slack_channel_presenter_spec.rb
+++ b/spec/presenters/slack_channel_presenter_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SlackChannelPresenter do
+  subject { SlackChannelPresenter.new(channel) }
+
+  describe '#cleaned_purpose' do
+    context 'when purpose contains a Slack-style channel mention' do
+      let(:channel) { double('purpose' => 'See <#C123456|job-seekers> for openings') }
+
+      it 'replaces Slack channel mention with readable text' do
+        expect(subject.cleaned_purpose).to eq 'See #job-seekers for openings'
+      end
+    end
+
+    context 'when purpose is blank' do
+      let(:channel) { double('purpose' => '') }
+
+      it 'returns an empty string' do
+        expect(subject.cleaned_purpose).to eq ''
+      end
+    end
+
+    context 'when purpose does not contain Slack markup' do
+      let(:channel) { double('purpose' => 'Talk about code') }
+
+      it 'returns the original purpose' do
+        expect(subject.cleaned_purpose).to eq 'Talk about code'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before (current)
<img width="365" height="162" alt="image" src="https://github.com/user-attachments/assets/dde3e8c3-2d8b-46f3-b168-f9adde60b99b" />

After (fake data locally)
<img width="1442" height="623" alt="Screenshot 2025-07-14 at 2 33 58 PM" src="https://github.com/user-attachments/assets/8e08ec5d-0b3c-4d4e-9c3e-12314a84fe36" />
